### PR TITLE
Add dualpivotquicksort (Dual-Pivot Quicksort)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,6 +41,7 @@ compare performance in different situations.
       - Shell sort               Algorithms::Sort.shell_sort
       - Quicksort                Algorithms::Sort.quicksort
       - Mergesort                Algorithms::Sort.mergesort
+      - Dual-Pivot Quicksort     Algorithms::Sort.dualpivotquicksort
 
 ## SYNOPSIS:
 

--- a/lib/algorithms.rb
+++ b/lib/algorithms.rb
@@ -43,6 +43,7 @@
     - Shell sort            - Algorithms::Sort.shell_sort
     - Quicksort             - Algorithms::Sort.quicksort
     - Mergesort             - Algorithms::Sort.mergesort
+    - Dual-Pivot Quicksort  - Algorithms::Sort.dualpivotquicksort
   * String algorithms
     - Levenshtein distance  - Algorithms::String.levenshtein_dist
 =end

--- a/spec/sort_spec.rb
+++ b/spec/sort_spec.rb
@@ -4,7 +4,8 @@ include Algorithms
 
 describe "sort algorithms" do
   before(:each) do
-    @sorts = %w(bubble_sort comb_sort selection_sort heapsort insertion_sort shell_sort quicksort mergesort)
+    @sorts = %w(bubble_sort comb_sort selection_sort heapsort insertion_sort 
+      shell_sort quicksort mergesort dualpivotquicksort)
   end
 
   it "should work for empty containers" do


### PR DESCRIPTION
Dual-Pivot Quicksort is a variation of Quicksort by
Vladimir Yaroslavskiy.

"This algorithm offers O(n log(n)) performance on many data sets
that cause other quicksorts to degrade to quadratic performance,
and is typically faster than traditional (one-pivot) Quicksort
implementations."
-- http://download.oracle.com/javase/7/docs/api/java/util/Arrays.html
