### PR TITLE
Explicit return not required for containers containing < 2 elements for insertion sort

### DIFF
--- a/lib/algorithms/sort.rb
+++ b/lib/algorithms/sort.rb
@@ -98,7 +98,6 @@ module Algorithms::Sort
   # 
   #   Algorithms::Sort.insertion_sort [5, 4, 3, 1, 2] => [1, 2, 3, 4, 5]
   def self.insertion_sort(container)
-    return container if container.size < 2
     (1..container.size-1).each do |i|
       value = container[i]
       j = i-1


### PR DESCRIPTION
If there are less than 2 elements then,

    (1..container.size-1)

will resolve to either 1..1 or 1..0 which will cause the loop to not even execute, hence will return the container itself.