### PR TITLE
Expect explicit errors with raise_error in specs

### DIFF
--- a/spec/deque_spec.rb
+++ b/spec/deque_spec.rb
@@ -27,7 +27,7 @@ shared_examples "(empty deque)" do
   end
 
   it "should raise ArgumentError if passed more than one argument" do
-    expect { @deque.class.send("new", Time.now, []) }.to raise_error
+    expect { @deque.class.send("new", Time.now, []) }.to raise_error(ArgumentError)
   end
 end
 

--- a/spec/heap_spec.rb
+++ b/spec/heap_spec.rb
@@ -7,8 +7,8 @@ describe Containers::Heap do
   end
   
   it "should not let you merge with non-heaps" do
-    expect { @heap.merge!(nil) }.to raise_error
-    expect { @heap.merge!([]) }.to raise_error
+    expect { @heap.merge!(nil) }.to raise_error(ArgumentError)
+    expect { @heap.merge!([]) }.to raise_error(ArgumentError)
   end
   
   describe "(empty)" do

--- a/spec/suffix_array_spec.rb
+++ b/spec/suffix_array_spec.rb
@@ -3,7 +3,7 @@ require 'algorithms'
 
 describe "empty suffix array" do
   it "should not initialize with empty string" do
-    expect { Containers::SuffixArray.new("") }.to raise_error
+    expect { Containers::SuffixArray.new("") }.to raise_error(ArgumentError)
   end
 end
 


### PR DESCRIPTION
Using raise_error without an explicit error can result in false
positive passes if the method under test raises any error, not just the
that is interesting to the spec.