### PR TITLE
Update dependencies and fix spec warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,26 +6,26 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.5)
-    rake (11.1.1)
-    rake-compiler (0.9.7)
+    diff-lcs (1.4.4)
+    rake (13.0.3)
+    rake-compiler (1.1.1)
       rake
-    rspec (3.4.0)
-      rspec-core (~> 3.4.0)
-      rspec-expectations (~> 3.4.0)
-      rspec-mocks (~> 3.4.0)
-    rspec-core (3.4.4)
-      rspec-support (~> 3.4.0)
-    rspec-expectations (3.4.0)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-mocks (3.4.1)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-support (3.4.1)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   algorithms!
@@ -33,4 +33,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.11.2
+   2.2.10

--- a/lib/algorithms/sort.rb
+++ b/lib/algorithms/sort.rb
@@ -310,7 +310,7 @@ module Algorithms::Sort
       pivot2 = container[right]
       # pointers
       less = left + 1
-      great = right -1
+      great = right - 1
       # sorting
       k = less
       while k <= great

--- a/spec/deque_spec.rb
+++ b/spec/deque_spec.rb
@@ -27,7 +27,7 @@ shared_examples "(empty deque)" do
   end
 
   it "should raise ArgumentError if passed more than one argument" do
-    expect { @deque.class.send("new", Time.now, []) }.to raise_error
+    expect { @deque.class.send("new", Time.now, []) }.to raise_error(ArgumentError)
   end
 end
 

--- a/spec/heap_spec.rb
+++ b/spec/heap_spec.rb
@@ -7,8 +7,8 @@ describe Containers::Heap do
   end
   
   it "should not let you merge with non-heaps" do
-    expect { @heap.merge!(nil) }.to raise_error
-    expect { @heap.merge!([]) }.to raise_error
+    expect { @heap.merge!(nil) }.to raise_error(ArgumentError)
+    expect { @heap.merge!([]) }.to raise_error(ArgumentError)
   end
   
   describe "(empty)" do

--- a/spec/suffix_array_spec.rb
+++ b/spec/suffix_array_spec.rb
@@ -3,7 +3,7 @@ require 'algorithms'
 
 describe "empty suffix array" do
   it "should not initialize with empty string" do
-    expect { Containers::SuffixArray.new("") }.to raise_error
+    expect { Containers::SuffixArray.new("") }.to raise_error(ArgumentError)
   end
 end
 


### PR DESCRIPTION
1. I think the gem versions here are probably four years old, so I thought it might be helpful to update them.
2. I fixed some rspec warnings about calling `raise_error` without passing an error class.
3. Added a space to make `right -1` into `right - 1` to eliminate the JRuby warning:

```
...algorithms/lib/algorithms/sort.rb:313: warning: `-' after local variable or literal is interpreted as binary operator
...algorithms/lib/algorithms/sort.rb:313: warning: even though it seems like unary operator
```