### PR TITLE
Fix `push` to be O(1).

### DIFF
--- a/lib/containers/heap.rb
+++ b/lib/containers/heap.rb
@@ -75,13 +75,6 @@ class Containers::Heap
     end
     @size += 1
     
-    arr = []
-    w = @next.right
-    until w == @next do
-      arr << w.value
-      w = w.right
-    end
-    arr << @next.value
     @stored[key] ||= []
     @stored[key] << node
     value


### PR DESCRIPTION
The method comment says it is O(1) but the code was O(n). It was doing an unnecessary loop.

This reduces the time for the ["Insertion then sort"](https://github.com/kanwei/algorithms/pull/46/files) benchmark from 7.659 to 0.011.

Fixes #36.

Related: https://github.com/kanwei/algorithms/pull/46 needs to be merged. It has the benchmark that I ran.

cc @alexkalderimis 