### PR TITLE
Remove Enumerable from heap and priority queue

### DIFF
--- a/lib/containers/heap.rb
+++ b/lib/containers/heap.rb
@@ -10,7 +10,6 @@
     This library implements a Fibonacci heap, which allows O(1) complexity for most methods.
 =end
 class Containers::Heap
-  include Enumerable
   
   # call-seq:
   #     size -> int

--- a/lib/containers/priority_queue.rb
+++ b/lib/containers/priority_queue.rb
@@ -10,7 +10,6 @@ require 'containers/heap'
     This container is implemented using the Fibonacci heap included in the Collections library.
 =end
 class Containers::PriorityQueue
-  include Enumerable
   
   # Create a new, empty PriorityQueue
   def initialize(&block)


### PR DESCRIPTION
This is related to https://github.com/kanwei/algorithms/issues/18

Because `each` is not implemented, there is no reason to include `Enumerable`.

I thought about implementing `each`; however, for heaps, that is tricky because if an object in a heap is modified, you could destroy the heap's properties. We could iteratively `pop` until the heap is empty and then `push` onto a new heap. But that might not be intuitive. 